### PR TITLE
課題3-2 フロントエンドのバリデーション（文字数カウントとバリデーション）

### DIFF
--- a/webapp/nextjs/app/editor/page.tsx
+++ b/webapp/nextjs/app/editor/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { validateTitle, validateContent } from '@/utils/validation';
 import TitleCounter from '@/components/editor/counter/TitleCounter';
 import CharacterCounter from '@/components/editor/counter/CharacterCounter';
 import { useState } from 'react';
@@ -95,6 +96,21 @@ function Editor({ initialTitle, initialContent }: EditorProps) {
 
   const handleSave = () => {
     if (!editor) return;
+
+    const text = editor.getText();
+
+    const titleError = validateTitle(title);
+    const contentError = validateContent(text);
+
+    if (titleError) {
+      alert(titleError);
+      return;
+    }
+
+    if (contentError) {
+      alert(contentError);
+      return;
+    }
 
     mutate({
       title,

--- a/webapp/nextjs/utils/validation.ts
+++ b/webapp/nextjs/utils/validation.ts
@@ -1,0 +1,22 @@
+export const MAX_TITLE_LENGTH = 100;
+export const MAX_CONTENT_LENGTH = 500;
+
+export function validateTitle(title: string) {
+  if (title.length === 0) {
+    return 'タイトルを入力してください';
+  }
+
+  if (title.length > MAX_TITLE_LENGTH) {
+    return `タイトルは${MAX_TITLE_LENGTH}文字以内にしてください`;
+  }
+
+  return null;
+}
+
+export function validateContent(text: string) {
+  if (text.length > MAX_CONTENT_LENGTH) {
+    return `本文は${MAX_CONTENT_LENGTH}文字以内にしてください`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
タイトルまたは本文が以下の文字数を超えている状態で保存しようとした場合に、フロントエンドでエラーメッセージを表示して保存できないようにした。

タイトル：100文字
本文：500文字