### PR TITLE
AIが記事を修正する際にプレビューを表示し、承認を得たときのみ本文を変更するように修正

### DIFF
--- a/webapp/nextjs/components/ai/AIFixPanel.tsx
+++ b/webapp/nextjs/components/ai/AIFixPanel.tsx
@@ -9,17 +9,20 @@ type Props = {
   approverComment: string | null;
 };
 
+type State = 'idle' | 'generating' | 'review';
+
 export default function AIFixPanel({ editor, title, approverComment }: Props) {
-  const [isFixingAI, setIsFixingAI] = useState(false);
+  const [state, setState] = useState<State>('idle');
   const [summary, setSummary] = useState('');
+  const [previewHtml, setPreviewHtml] = useState('');
 
   if (!approverComment) return null;
 
-  const handleFix = async () => {
+  const handleGenerate = async () => {
     if (!editor) return;
 
     const text = editor.getText();
-    setIsFixingAI(true);
+    setState('generating');
 
     try {
       const res = await fetch('/api/ai-fix-article', {
@@ -32,24 +35,40 @@ export default function AIFixPanel({ editor, title, approverComment }: Props) {
 
       const data = await res.json();
 
-      if (data.fixedContent) {
-        editor.commands.setContent(data.fixedContent);
-      }
-
+      setPreviewHtml(data.fixedContent || '');
       setSummary(data.summary || '');
+
+      setState('review');
     } catch (e) {
       console.error(e);
       alert('AI修正に失敗しました');
-    } finally {
-      setIsFixingAI(false);
+      setState('idle');
     }
+  };
+
+  const handleAccept = () => {
+    if (!editor) return;
+
+    editor.commands.setContent(previewHtml);
+
+    setPreviewHtml('');
+    setSummary('');
+    setState('idle');
+  };
+
+  const handleReject = () => {
+    setPreviewHtml('');
+    setSummary('');
+    setState('idle');
   };
 
   return (
     <div style={{ marginBottom: '16px' }}>
+
+      {/* 修正ボタン */}
       <button
-        onClick={handleFix}
-        disabled={isFixingAI}
+        onClick={handleGenerate}
+        disabled={state === 'generating'}
         style={{
           padding: '8px 16px',
           borderRadius: '6px',
@@ -57,28 +76,78 @@ export default function AIFixPanel({ editor, title, approverComment }: Props) {
           fontWeight: 'bold',
           backgroundColor: '#10b981',
           color: 'white',
-          cursor: isFixingAI ? 'not-allowed' : 'pointer',
-          opacity: isFixingAI ? 0.5 : 1
+          cursor: state === 'generating' ? 'not-allowed' : 'pointer',
+          opacity: state === 'generating' ? 0.5 : 1
         }}
       >
-        {isFixingAI ? 'AI修正中...' : 'AIで修正'}
+        {state === 'generating'
+          ? '生成中...'
+          : state === 'review'
+          ? '再生成'
+          : 'AIで修正'}
       </button>
 
-      {summary && (
+      {/* 承認待ちパネル */}
+      {state === 'review' && (
         <div
           style={{
             marginTop: '12px',
-            padding: '12px',
-            backgroundColor: '#ecfeff',
-            border: '1px solid #06b6d4',
-            borderRadius: '6px',
-            fontSize: '14px'
+            padding: '16px',
+            backgroundColor: '#f8fafc',
+            border: '1px solid #cbd5f5',
+            borderRadius: '8px'
           }}
         >
-          <b>AI修正の概要</b>
-          <p style={{ marginTop: '6px', whiteSpace: 'pre-wrap' }}>
-            {summary}
-          </p>
+          {summary && (
+            <>
+              <b>AI修正の概要</b>
+              <p style={{ marginTop: '6px', whiteSpace: 'pre-wrap' }}>
+                {summary}
+              </p>
+            </>
+          )}
+
+          <div
+            style={{
+              marginTop: '12px',
+              padding: '12px',
+              border: '1px solid #e5e7eb',
+              borderRadius: '6px',
+              background: 'white',
+              maxHeight: '300px',
+              overflow: 'auto'
+            }}
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+
+          <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+            <button
+              onClick={handleAccept}
+              style={{
+                padding: '8px 16px',
+                borderRadius: '6px',
+                border: 'none',
+                backgroundColor: '#2563eb',
+                color: 'white',
+                fontWeight: 'bold'
+              }}
+            >
+              採用
+            </button>
+
+            <button
+              onClick={handleReject}
+              style={{
+                padding: '8px 16px',
+                borderRadius: '6px',
+                border: '1px solid #d1d5db',
+                backgroundColor: 'white',
+                fontWeight: 'bold'
+              }}
+            >
+              不採用
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## 概要
AIが記事を修正する際に、生成結果を即座に本文へ反映するのではなく、プレビューで内容を確認し、ユーザーが承認した場合のみ本文へ反映するフローを追加しました。

### Issue番号
Closes #87

## 変更内容
- [x] 機能を追加
- [ ] バグを修正

### 実装内容
- AI修正機能に **状態管理（待機 / 生成中 / 承認待ち）** を追加
- AI生成結果を **即本文へ反映せずプレビューとして表示**
- プレビュー下部に **採用 / 不採用ボタン** を追加
- 採用時のみ `editor.commands.setContent()` により本文を更新
- 不採用時は本文を変更せず待機状態に戻る
- 承認待ち状態では **再生成ボタン** を表示
- コメントが存在する場合のみAI修正機能が有効になる既存仕様を維持

## 影響範囲
- `AIFixPanel` のUIおよび状態管理ロジック
- AI修正APIのレスポンス内容を **直接反映 → プレビュー表示** に変更

既存のエディタ機能やAI生成機能（記事作成）は影響を受けません。

## チェックリスト
- [ ] コード規約に従って記述しているか
- [ ] テストを追加・修正し、全てパスしているか
- [ ] 不要なコメントや `console.log` などを削除したか